### PR TITLE
Add tabwidth argument to lll

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ go get github.com/walle/lll/...
 ## Usage
 
 ```shell
-usage: lll [--maxlength MAXLENGTH] [--goonly] [--skiplist SKIPLIST] [--vendor] [--files] [--exclude EXCLUDE] [INPUT [INPUT ...]]
+usage: lll [--maxlength MAXLENGTH] [--tabwidth TABWIDTH] [--goonly] [--skiplist SKIPLIST] [--vendor] [--files] [--exclude EXCLUDE] [INPUT [INPUT ...]]
 
 positional arguments:
   input
@@ -26,6 +26,8 @@ positional arguments:
 options:
   --maxlength MAXLENGTH, -l MAXLENGTH
                          max line length to check for [default: 80]
+  --tabwidth TABWIDTH, -w TABWIDTH
+                         tab width in spaces [default: 1]
   --goonly, -g           only check .go files
   --skiplist SKIPLIST, -s SKIPLIST
                          list of dirs to skip [default: [.git vendor]]

--- a/cmd/lll/main.go
+++ b/cmd/lll/main.go
@@ -14,6 +14,7 @@ import (
 
 var args struct {
 	MaxLength int      `arg:"-l,env,help:max line length to check for"`
+	TabWidth  int      `arg:"-w,env,help:tab width in spaces"`
 	GoOnly    bool     `arg:"-g,env,help:only check .go files"`
 	Input     []string `arg:"positional"`
 	SkipList  []string `arg:"-s,env,help:list of dirs to skip"`
@@ -24,6 +25,7 @@ var args struct {
 
 func main() {
 	args.MaxLength = 80
+	args.TabWidth = 1
 	args.SkipList = []string{".git", "vendor"}
 	arg.MustParse(&args)
 
@@ -50,7 +52,7 @@ func main() {
 	if args.Files {
 		s := bufio.NewScanner(os.Stdin)
 		for s.Scan() {
-			err := lll.ProcessFile(os.Stdout, s.Text(), args.MaxLength, exclude)
+			err := lll.ProcessFile(os.Stdout, s.Text(), args.MaxLength, args.TabWidth, exclude)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error processing file: %s\n", err)
 			}
@@ -74,7 +76,7 @@ func main() {
 				return ret
 			}
 
-			err := lll.ProcessFile(os.Stdout, p, args.MaxLength, exclude)
+			err := lll.ProcessFile(os.Stdout, p, args.MaxLength, args.TabWidth, exclude)
 			return err
 		})
 

--- a/lll.go
+++ b/lll.go
@@ -55,7 +55,7 @@ func ShouldSkip(path string, isDir bool, skipList []string,
 
 // ProcessFile checks all lines in the file and writes an error if the line
 // length is greater than MaxLength.
-func ProcessFile(w io.Writer, path string, maxLength int,
+func ProcessFile(w io.Writer, path string, maxLength, tabWidth int,
 	exclude *regexp.Regexp) error {
 	f, err := os.Open(path)
 	if err != nil {
@@ -68,17 +68,19 @@ func ProcessFile(w io.Writer, path string, maxLength int,
 		}
 	}()
 
-	return Process(f, w, path, maxLength, exclude)
+	return Process(f, w, path, maxLength, tabWidth, exclude)
 }
 
 // Process checks all lines in the reader and writes an error if the line length
 // is greater than MaxLength.
-func Process(r io.Reader, w io.Writer, path string, maxLength int,
+func Process(r io.Reader, w io.Writer, path string, maxLength, tabWidth int,
 	exclude *regexp.Regexp) error {
+	spaces := strings.Repeat(" ", tabWidth)
 	l := 1
 	s := bufio.NewScanner(r)
 	for s.Scan() {
 		t := s.Text()
+		t = strings.Replace(t, "\t", spaces, -1)
 		c := utf8.RuneCountInString(t)
 		if c > maxLength {
 			if exclude != nil {

--- a/lll_test.go
+++ b/lll_test.go
@@ -46,13 +46,13 @@ func TestShouldSkipFiles(t *testing.T) {
 func TestProcess(t *testing.T) {
 	lines := "one\ntwo\ntree"
 	b := bytes.NewBufferString("")
-	err := lll.Process(bytes.NewBufferString(lines), b, "file", 80, nil)
+	err := lll.Process(bytes.NewBufferString(lines), b, "file", 80, 1, nil)
 	if err != nil {
 		t.Errorf("Expected %s, got %s", nil, err)
 	}
 
 	expected := "file:3: line is 4 characters\n"
-	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 3, nil)
+	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 3, 1, nil)
 	if b.String() != expected {
 		t.Errorf("Expected %s, got %s", expected, b.String())
 	}
@@ -60,7 +60,7 @@ func TestProcess(t *testing.T) {
 
 func TestProcessFile(t *testing.T) {
 	b := bytes.NewBufferString("")
-	err := lll.ProcessFile(b, "lll_test.go", 80, nil)
+	err := lll.ProcessFile(b, "lll_test.go", 80, 1, nil)
 	if err != nil {
 		t.Errorf("Expected %s, got %s", nil, err)
 	}
@@ -70,7 +70,27 @@ func TestProcessUnicode(t *testing.T) {
 	lines := "日本語\n"
 	b := bytes.NewBufferString("")
 	expected := "file:1: line is 3 characters\n"
-	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 2, nil)
+	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 2, 1, nil)
+	if b.String() != expected {
+		t.Errorf("Expected %s, got %s", expected, b.String())
+	}
+}
+
+func TestProcessWithTabwidth4(t *testing.T) {
+	lines := "\t\t\terr := lll.ProcessFile(os.Stdout, s.Text(), args.MaxLength, args.TabWidth, exclude)"
+	b := bytes.NewBufferString("")
+	expected := "file:1: line is 95 characters\n"
+	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 80, 4, nil)
+	if b.String() != expected {
+		t.Errorf("Expected %s, got %s", expected, b.String())
+	}
+}
+
+func TestProcessWithTabwidth8(t *testing.T) {
+	lines := "\t\t\terr := lll.ProcessFile(os.Stdout, s.Text(), args.MaxLength, args.TabWidth, exclude)"
+	b := bytes.NewBufferString("")
+	expected := "file:1: line is 107 characters\n"
+	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 80, 8, nil)
 	if b.String() != expected {
 		t.Errorf("Expected %s, got %s", expected, b.String())
 	}
@@ -81,7 +101,7 @@ func TestProcessExclude(t *testing.T) {
 	b := bytes.NewBufferString("")
 	exclude := regexp.MustCompile("TODO|FIXME")
 	expected := "file:3: line is 4 characters\n"
-	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 3, exclude)
+	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 3, 1, exclude)
 	if b.String() != expected {
 		t.Errorf("Expected %s, got %s", expected, b.String())
 	}
@@ -94,7 +114,7 @@ func BenchmarkProcessExclude(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		buf := bytes.NewBufferString("")
-		_ = lll.Process(bytes.NewBufferString(lines), buf, "file", 3, exclude)
+		_ = lll.Process(bytes.NewBufferString(lines), buf, "file", 3, 1, exclude)
 		if buf.String() != expected {
 			b.Errorf("Expected %s, got %s", expected, buf.String())
 		}


### PR DESCRIPTION
The tabwidth argument to lll makes it possible to configure how many
characters a tab should be counted as.  This is useful for reporting
long lines which are indented.

The default value is 1, meaning legacy behavior is kept.  By setting the
tabwidth, it's easy to get warnings about other tab width settings, such
as 4 and 8.