### PR TITLE
Increment line count even if line is ignored

### DIFF
--- a/lll.go
+++ b/lll.go
@@ -76,9 +76,10 @@ func ProcessFile(w io.Writer, path string, maxLength, tabWidth int,
 func Process(r io.Reader, w io.Writer, path string, maxLength, tabWidth int,
 	exclude *regexp.Regexp) error {
 	spaces := strings.Repeat(" ", tabWidth)
-	l := 1
+	l := 0
 	s := bufio.NewScanner(r)
 	for s.Scan() {
+		l++
 		t := s.Text()
 		t = strings.Replace(t, "\t", spaces, -1)
 		c := utf8.RuneCountInString(t)
@@ -90,7 +91,6 @@ func Process(r io.Reader, w io.Writer, path string, maxLength, tabWidth int,
 			}
 			fmt.Fprintf(w, "%s:%d: line is %d characters\n", path, l, c)
 		}
-		l++
 	}
 
 	if err := s.Err(); err != nil {

--- a/lll_test.go
+++ b/lll_test.go
@@ -99,10 +99,10 @@ func TestProcessWithTabwidth8(t *testing.T) {
 }
 
 func TestProcessExclude(t *testing.T) {
-	lines := "one\ntwo\ntree\nTODO: fix\nFIXME: do this"
+	lines := "one\ntwo\nTODO: fix\ntree\nFIXME: do this"
 	b := bytes.NewBufferString("")
 	exclude := regexp.MustCompile("TODO|FIXME")
-	expected := "file:3: line is 4 characters\n"
+	expected := "file:4: line is 4 characters\n"
 	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 3, 1, exclude)
 	if b.String() != expected {
 		t.Errorf("Expected %s, got %s", expected, b.String())

--- a/lll_test.go
+++ b/lll_test.go
@@ -12,34 +12,34 @@ import (
 func TestShouldSkipDirs(t *testing.T) {
 	skip, ret := lll.ShouldSkip(".git", true, []string{".git"}, false)
 	if skip == false || ret != filepath.SkipDir {
-		t.Errorf("Expected %b, %s got. %b, %s", true, filepath.SkipDir, skip, ret)
+		t.Errorf("Expected %t, %s got. %t, %s", true, filepath.SkipDir, skip, ret)
 	}
 
 	skip, ret = lll.ShouldSkip("dir", true, []string{".git"}, false)
 	if skip == false || ret != nil {
-		t.Errorf("Expected %b, %s got. %b, %s", true, nil, skip, ret)
+		t.Errorf("Expected %t, %v got. %t, %s", true, nil, skip, ret)
 	}
 }
 
 func TestShouldSkipFiles(t *testing.T) {
 	skip, ret := lll.ShouldSkip("file.go", false, []string{".git"}, true)
 	if skip == true || ret != nil {
-		t.Errorf("Expected %b, %s got. %b, %s", false, nil, skip, ret)
+		t.Errorf("Expected %t, %v got. %t, %s", false, nil, skip, ret)
 	}
 
 	skip, ret = lll.ShouldSkip("file", false, []string{".git"}, true)
 	if skip == false || ret != nil {
-		t.Errorf("Expected %b, %s got. %b, %s", true, nil, skip, ret)
+		t.Errorf("Expected %t, %v got. %t, %s", true, nil, skip, ret)
 	}
 
 	skip, ret = lll.ShouldSkip("lll_test.go", false, []string{".git"}, false)
 	if skip == true || ret != nil {
-		t.Errorf("Expected %b, %s got. %b, %s", false, nil, skip, ret)
+		t.Errorf("Expected %t, %v got. %t, %s", false, nil, skip, ret)
 	}
 
 	skip, ret = lll.ShouldSkip("file", false, []string{"file"}, false)
 	if skip == false || ret != nil {
-		t.Errorf("Expected %b, %s got. %b, %s", true, nil, skip, ret)
+		t.Errorf("Expected %t, %v got. %t, %s", true, nil, skip, ret)
 	}
 }
 
@@ -48,7 +48,7 @@ func TestProcess(t *testing.T) {
 	b := bytes.NewBufferString("")
 	err := lll.Process(bytes.NewBufferString(lines), b, "file", 80, 1, nil)
 	if err != nil {
-		t.Errorf("Expected %s, got %s", nil, err)
+		t.Errorf("Expected %v, got %s", nil, err)
 	}
 
 	expected := "file:3: line is 4 characters\n"
@@ -62,7 +62,7 @@ func TestProcessFile(t *testing.T) {
 	b := bytes.NewBufferString("")
 	err := lll.ProcessFile(b, "lll_test.go", 80, 1, nil)
 	if err != nil {
-		t.Errorf("Expected %s, got %s", nil, err)
+		t.Errorf("Expected %v, got %s", nil, err)
 	}
 }
 


### PR DESCRIPTION
If a line was configured to be skipped, the line count was not incremented, resulting in the wrong offending lines to be reported back to the user.