### PR TITLE
Add a new flag to control line-length of comment lines separately.

### DIFF
--- a/cmd/lll/main.go
+++ b/cmd/lll/main.go
@@ -27,7 +27,7 @@ var args struct {
 
 func main() {
 	args.MaxLength = 80
-	args.MaxCommentLength = 80
+	args.MaxCommentLength = args.MaxLength
 	args.TabWidth = 1
 	args.SkipList = []string{".git", "vendor"}
 	arg.MustParse(&args)

--- a/cmd/lll/main.go
+++ b/cmd/lll/main.go
@@ -14,7 +14,7 @@ import (
 
 var args struct {
 	MaxLength        int      `arg:"-l,env,help:max line length to check for"`
-	MaxCommentLength int      `arg:"-l,env,help:max line length to check for for comment lines"`
+	MaxCommentLength int      `arg:"-c,env,help:max line length to check for for comment lines"`
 	TabWidth         int      `arg:"-w,env,help:tab width in spaces"`
 	GoOnly           bool     `arg:"-g,env,help:only check .go files"`
 	SkipTests        bool     `arg:"-t,env,help:skip _test.go files"`

--- a/lll_test.go
+++ b/lll_test.go
@@ -79,13 +79,13 @@ func TestShouldSkipFiles(t *testing.T) {
 func TestProcess(t *testing.T) {
 	lines := "one\ntwo\ntree"
 	b := bytes.NewBufferString("")
-	err := lll.Process(bytes.NewBufferString(lines), b, "file", 80, 1, nil)
+	err := lll.Process(bytes.NewBufferString(lines), b, "file", 80, 80, 1, nil)
 	if err != nil {
 		t.Errorf("Expected %v, got %s", nil, err)
 	}
 
 	expected := "file:3: line is 4 characters\n"
-	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 3, 1, nil)
+	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 3, 3, 1, nil)
 	if b.String() != expected {
 		t.Errorf("Expected %s, got %s", expected, b.String())
 	}
@@ -93,7 +93,7 @@ func TestProcess(t *testing.T) {
 
 func TestProcessFile(t *testing.T) {
 	b := bytes.NewBufferString("")
-	err := lll.ProcessFile(b, "lll_test.go", 80, 1, nil)
+	err := lll.ProcessFile(b, "lll_test.go", 80, 80, 1, nil)
 	if err != nil {
 		t.Errorf("Expected %v, got %s", nil, err)
 	}
@@ -103,7 +103,7 @@ func TestProcessUnicode(t *testing.T) {
 	lines := "日本語\n"
 	b := bytes.NewBufferString("")
 	expected := "file:1: line is 3 characters\n"
-	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 2, 1, nil)
+	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 2, 2, 1, nil)
 	if b.String() != expected {
 		t.Errorf("Expected %s, got %s", expected, b.String())
 	}
@@ -114,7 +114,7 @@ func TestProcessWithTabwidth4(t *testing.T) {
 		"args.MaxLength, args.TabWidth, exclude)"
 	b := bytes.NewBufferString("")
 	expected := "file:1: line is 95 characters\n"
-	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 80, 4, nil)
+	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 80, 80, 4, nil)
 	if b.String() != expected {
 		t.Errorf("Expected %s, got %s", expected, b.String())
 	}
@@ -125,7 +125,7 @@ func TestProcessWithTabwidth8(t *testing.T) {
 		"args.MaxLength, args.TabWidth, exclude)"
 	b := bytes.NewBufferString("")
 	expected := "file:1: line is 107 characters\n"
-	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 80, 8, nil)
+	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 80, 80, 8, nil)
 	if b.String() != expected {
 		t.Errorf("Expected %s, got %s", expected, b.String())
 	}
@@ -136,7 +136,17 @@ func TestProcessExclude(t *testing.T) {
 	b := bytes.NewBufferString("")
 	exclude := regexp.MustCompile("TODO|FIXME")
 	expected := "file:4: line is 4 characters\n"
-	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 3, 1, exclude)
+	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 3, 3, 1, exclude)
+	if b.String() != expected {
+		t.Errorf("Expected %s, got %s", expected, b.String())
+	}
+}
+
+func TestProcessCommentLines(t *testing.T) {
+	lines := "one\ntwo\n// three\n\t// four"
+	b := bytes.NewBufferString("")
+	expected := "file:4: line is 11 characters\n"
+	_ = lll.Process(bytes.NewBufferString(lines), b, "file", 80, 10, 4, nil)
 	if b.String() != expected {
 		t.Errorf("Expected %s, got %s", expected, b.String())
 	}
@@ -149,7 +159,7 @@ func BenchmarkProcessExclude(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		buf := bytes.NewBufferString("")
-		_ = lll.Process(bytes.NewBufferString(lines), buf, "file", 3, 1, exclude)
+		_ = lll.Process(bytes.NewBufferString(lines), buf, "file", 3, 3, 1, exclude)
 		if buf.String() != expected {
 			b.Errorf("Expected %s, got %s", expected, buf.String())
 		}

--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,7 @@ package lll
 import (
 	"bufio"
 	"bytes"
+	"strings"
 )
 
 var (
@@ -21,4 +22,11 @@ func isGenerated(src []byte) bool {
 		}
 	}
 	return false
+}
+
+// isComment reports whether a given line of input is a comment line.
+// It does this by checking if the line starts with `//` (excluding tabs).
+func isComment(line string) bool {
+	trimmedLine := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmedLine, "// ")
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -15,7 +15,25 @@ func TestIsGenerated(t *testing.T) {
 	for _, c := range cases {
 		isGenerated := isGenerated(c.fileContents)
 		if isGenerated != c.generated {
-			t.Errorf("expected %t, got %t", isGenerated, c.generated)
+			t.Errorf("expected %t, got %t", c.generated, isGenerated)
+		}
+	}
+}
+
+func TestHasComment(t *testing.T) {
+	cases := []struct {
+		line    string
+		comment bool
+	}{
+		{"// comment line", true},
+		{"\t\t// comment line", true},
+		{"//+build line not considered a comment", false},
+		{"\tcomment at end // of line", false},
+	}
+	for _, c := range cases {
+		isComment := isComment(c.line)
+		if isComment != c.comment {
+			t.Errorf("expected %t, got %t", c.comment, isComment)
 		}
 	}
 }


### PR DESCRIPTION
This allows users to have a longer line-length limit for code than for
natural-language text.

One example is a project that wants "most" code to fit in 80 columns,
but will allow the occassional long line.  The best way to implement
this in `lll` right now is to have a longer line limit (say, 100
columns) with an understanding the code-reviewers will make sure most
lines are not over 80 columns.  But we still want all comment lines to
fit within 80 columns, since there's no good reason for them not to.
This new flag allows for that.