### PR TITLE
Ignore go generate directives

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ feature request. Tag the issue accordingly.
 
 1. Install as usual (`go get github.com/walle/lll`)
 2. Write code and tests for your new feature
-3. Ensure everything works and the tests pass (see below)
+3. Ensure everything works, and the tests pass (see below)
 4. Consider contributing your code upstream
 
 ### Contribute upstream
@@ -23,7 +23,7 @@ feature request. Tag the issue accordingly.
 5. Write code and tests for your new feature
 6. Rebase against upstream to get changes \
 (`git fetch origin && git rebase origin/master`)
-7. Ensure everything works and the tests pass (see below)
+7. Ensure everything works, and the tests pass (see below)
 8. Commit your changes
 9. Push the branch to github (`git push fork my-new-feature`)
 10. Create a new Pull Request on GitHub

--- a/lll.go
+++ b/lll.go
@@ -85,6 +85,9 @@ func Process(r io.Reader, w io.Writer, path string, maxLength, tabWidth int,
 		l++
 		t := s.Text()
 		t = strings.Replace(t, "\t", spaces, -1)
+		if isGoGenerate(t) {
+			continue
+		}
 		c := utf8.RuneCountInString(t)
 		if c > maxLength {
 			if exclude != nil {

--- a/lll_test.go
+++ b/lll_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/walle/lll"
 )
 
+// Long directive example, tested by TestProcessFile
+//go:generate mockgen --build_flags=-mod=mod -destination mocks/mocks.go -package scoringmocks . IGGStorage,IEventsStorage
+
 func TestShouldSkipDirs(t *testing.T) {
 	skip, err := lll.ShouldSkip(".git", true, []string{".git"}, false, false)
 	if skip == false || err != filepath.SkipDir {
@@ -93,9 +96,12 @@ func TestProcess(t *testing.T) {
 
 func TestProcessFile(t *testing.T) {
 	b := bytes.NewBufferString("")
-	err := lll.ProcessFile(b, "lll_test.go", 80, 1, nil)
+	err := lll.ProcessFile(b, "lll_test.go", 100, 1, nil)
 	if err != nil {
 		t.Errorf("Expected %v, got %s", nil, err)
+	}
+	if b.Len() > 0 {
+		t.Errorf(`Unexpected issues in "lll_test.go": %v`, b.String())
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -3,11 +3,13 @@ package lll
 import (
 	"bufio"
 	"bytes"
+	"strings"
 )
 
 var (
-	genHdr = []byte("// Code generated ")
-	genFtr = []byte(" DO NOT EDIT.")
+	genHdr           = []byte("// Code generated ")
+	genFtr           = []byte(" DO NOT EDIT.")
+	goGeneratePrefix = "//go:generate "
 )
 
 // isGenerated reports whether the source file is generated code
@@ -21,4 +23,10 @@ func isGenerated(src []byte) bool {
 		}
 	}
 	return false
+}
+
+// isGoGenerate reports whether the code line is "go generate" directive
+// https://github.com/golang/go/blob/master/src/cmd/go/internal/generate/generate.go#L324
+func isGoGenerate(line string) bool {
+	return strings.HasPrefix(line, goGeneratePrefix)
 }


### PR DESCRIPTION
Hello!

We now have to do this, which is not very beautiful

```golang
//nolint:lll
//go:generate mockgen -source=$GOFILE --build_flags=-mod=mod -destination mocks/mocks.go -package eventsubscriptionmocks . IAvailability,IMarketsConfig,ILPClient
```